### PR TITLE
Delay modal page opening after QR code scan

### DIFF
--- a/popcoin/app/drawers/home/mytoken/mytoken-page.js
+++ b/popcoin/app/drawers/home/mytoken/mytoken-page.js
@@ -127,13 +127,14 @@ function popTokenTapped(args) {
                         const fields = {
                             signature: Convert.byteArrayToHex(sig)
                         };
-
-
-                        pageObject.showModal("shared/pages/qr-code/qr-code-page", {
-                            textToShow: Convert.objectToJson(fields),
-                            title: "Signed informations"
-                        }, () => {
-                        }, true);
+                        
+                        setTimeout(() => {
+                            pageObject.showModal("shared/pages/qr-code/qr-code-page", {
+                                textToShow: Convert.objectToJson(fields),
+                                title: "Signed informations"
+                            }, () => {
+                            }, true);
+                        }, 1);
 
                         return Promise.resolve()
                     })


### PR DESCRIPTION
This PR adds a a delay after scanning a QR Code in the pop token part. This allows the modal page to correctly open on iOS. This is a workaround as this does not happen on Android.

Solves #65.