### PR TITLE
Fix WebSockets sending again old messages

### DIFF
--- a/popcoin/Makefile
+++ b/popcoin/Makefile
@@ -23,6 +23,7 @@ clean-install:
 	make install-dependencies
 	./prepare-hook.sh
 	patch -p0 < nodeify_temporary_patch.patch
+	patch -p0 < websockets_temporary_patch.patch
 
 ### Run App iOS
 run-ios:

--- a/popcoin/websockets_temporary_patch.patch
+++ b/popcoin/websockets_temporary_patch.patch
@@ -1,0 +1,14 @@
+This patch allows to correcly run nativescript-websockets on Android. Without this patch,
+the same objects are referenced when passed to this._socket.send, thus the websocket resend
+previous messages.
+
+--- node_modules/nativescript-websockets/websockets.ios.js	2018-08-13 10:31:03.000000000 +0200
++++ node_modules/nativescript-websockets/websockets.ios.js	2018-08-13 10:31:31.000000000 +0200
+@@ -305,6 +305,7 @@
+  * @returns {boolean} - returns false if it is unable to send the message at this time, it will queue them up and try later...
+  */
+ NativeWebSockets.prototype.send = function(message) {
++    message = message.slice(0);
+     var state = this.state();
+ 
+     // If we have a queue, we need to start processing it...


### PR DESCRIPTION
This seemed to be an intrinsic issue to NativeScript. The message passed from the JavaScript VM to the native code is not correctly converted and points to the same (old) object as the previous message. This is a temporary fix, we'll try to get in touch with the developers of native script-websockets or NativeScript to apply a long-term fix.

Closes #71 