### PR TITLE
Remove a temporary fix for the roster ID

### DIFF
--- a/popcoin/app/shared/lib/dedjs/object/pop/Party.js
+++ b/popcoin/app/shared/lib/dedjs/object/pop/Party.js
@@ -42,9 +42,6 @@ class Party {
             id = popDescModule.roster.id;
         }
 
-        // Temporary fix as CothrorityJS needs a mandatory ID
-        id = Uint8Array.from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
-
         const list = [];
         popDescModule.roster.list.forEach(server => {
             list.push(CothorityMessages.createServerIdentity(


### PR DESCRIPTION
Recent changes in protobufs definitions made the ID of a roster mandadory, but the app doesn't not set the ID, thus the messages were refused by the conodes. This has been fixed by adding a "default" ID to every roster, but this not necessary anymore thanks to https://github.com/dedis/cothority/pull/1420