### PR TITLE
Upgrade to NS 4.2 and fix iOS build problems

### DIFF
--- a/popcoin/Makefile
+++ b/popcoin/Makefile
@@ -17,6 +17,7 @@ clean-install: clean apply-patches
 apply-patches: init-npm
 	patch -p0 < nodeify_temporary_patch.patch
 	patch -p0 < websockets_temporary_patch.patch
+	patch -p0 < nodefiy-nativescript-support.patch
 
 init-npm:
 	$(npm) install

--- a/popcoin/nodefiy-nativescript-support.patch
+++ b/popcoin/nodefiy-nativescript-support.patch
@@ -1,0 +1,12 @@
+This patch allows the module nativescript-nodeidy to work on
+NativeScript v>4.1. It is taken from https://github.com/EddyVerbruggen/nativescript-nodeify/pull/50
+--- node_modules/nativescript-nodeify/patch-npm-packages.js
++++ node_modules/nativescript-nodeify/patch-npm-packages.js
+@@ -1,7 +1,7 @@
+ module.exports = function ($logger, $projectData, $usbLiveSyncService) {
+   var liveSync = $usbLiveSyncService.isInitialized;
+
+-  if (liveSync) {
++  if (!liveSync) {
+     return;
+   }

--- a/popcoin/package.json
+++ b/popcoin/package.json
@@ -11,10 +11,10 @@
       }
     },
     "tns-android": {
-      "version": "4.0.1"
+      "version": "4.2.0"
     },
     "tns-ios": {
-      "version": "4.0.1"
+      "version": "4.2.0"
     }
   },
   "scripts": {
@@ -39,17 +39,17 @@
     "nativescript-floatingactionbutton": "^4.1.3",
     "nativescript-iqkeyboardmanager": "^1.1.0",
     "nativescript-modal-datetimepicker": "^1.0.3",
-    "nativescript-nodeify": "^0.7.0",
+    "nativescript-nodeify": "0.7.0",
     "nativescript-theme-core": "1.0.4",
-    "nativescript-ui-dataform": "^3.5.2",
-    "nativescript-ui-listview": "^3.5.4",
-    "nativescript-ui-sidedrawer": "^3.5.2",
+    "nativescript-ui-dataform": "^3.7.0",
+    "nativescript-ui-listview": "^3.6.0",
+    "nativescript-ui-sidedrawer": "^4.3.0",
     "nativescript-unit-test-runner": "^0.3.4",
     "nativescript-websockets": "^1.5.1",
     "nativescript-zxing": "^1.5.3",
     "pure-uuid": "^1.4.8",
     "ssl-utils": "^0.3.0",
-    "tns-core-modules": "^4.1.1",
+    "tns-core-modules": "^4.2.0",
     "toml": "^2.3.3",
     "tomlify-j0.4": "^3.0.0",
     "uuid": "^3.2.1",


### PR DESCRIPTION
It's now possible to use the last version of NativeScript with the app. It also now builds correctly on iOS using `tns build ios --release --for-device --provision PROVISION_ID`